### PR TITLE
Add 'public' access modifier to EntityHeader

### DIFF
--- a/OnlinePayments.Sdk/EntityHeader.cs
+++ b/OnlinePayments.Sdk/EntityHeader.cs
@@ -6,7 +6,7 @@ namespace OnlinePayments.Sdk
     /// <summary>
     /// A header that specifies metadata about the content of the request or response. Immutable.
     /// </summary>
-    class EntityHeader : IRequestHeader, IResponseHeader
+    public class EntityHeader : IRequestHeader, IResponseHeader
     {
         public EntityHeader(string name, string value)
         {


### PR DESCRIPTION
I am currently writing a custom `IConnection` implementation, because the project I'm working on suffers from the same or a similar issue as #6. I would like my custom implementation to be as similar as possible to `DefaultConnection`. However, this is complicated because I can't access `EntityHeader` in my code.

I think that the fact that `EntityHeader` is `internal` because of the missing access modifier is unintended, so I propose to fix this through this PR.