### PR TITLE
Fix re-throw of exception

### DIFF
--- a/OnlinePayments.Sdk/DefaultImpl/DefaultConnection.cs
+++ b/OnlinePayments.Sdk/DefaultImpl/DefaultConnection.cs
@@ -176,7 +176,7 @@ namespace OnlinePayments.Sdk.DefaultImpl
             catch (CommunicationException exception)
             {
                 LogException(guid, exception);
-                throw exception;
+                throw;
             }
         }
 


### PR DESCRIPTION
The statement `throw exception;` creates a new stack trace, while `throw;` preserves the original one and is the preferred way to rethrow an exception.